### PR TITLE
Add eval-defun analogue

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ is likely:
 
     * Send buffer (`C-c C-b`)
     * Send expression at point (`C-x C-e`)
+    * Send top-level expression at point (`C-M-x`)
     * Send expression upscoped (`C-c C-u`) - see below for details
     * Send region (`C-c C-r`)
 

--- a/ajrepl.el
+++ b/ajrepl.el
@@ -56,9 +56,12 @@
 ;;
 ;;      Send buffer
 ;;      Send expression at point
+;;      Send top-level expression
+;;      Send expression upscoped
 ;;      Send region
 ;;
 ;;      Insert last output
+;;      Insert rest of usage
 ;;
 ;;      Start REPL
 ;;      Switch to REPL

--- a/ajrepl.el
+++ b/ajrepl.el
@@ -93,6 +93,7 @@
 
 (require 'comint)
 (require 'ajrepl-core)
+(require 'thingatpt)
 
 ;;;; The Rest
 
@@ -116,6 +117,15 @@
         (comint-send-input)
         (set-buffer original-buffer)
         (goto-char here)))))
+
+(defun ajrepl-send-top-level-expression ()
+  "Send top-level expression containing point."
+  (interactive)
+  (save-excursion
+    (when-let* ((defun-region (bounds-of-thing-at-point 'defun))
+                (beg (car defun-region))
+                (end (cdr defun-region)))
+      (ajrepl-send-region beg end))))
 
 (defun ajrepl-send-buffer ()
   "Send buffer content."
@@ -329,6 +339,7 @@ This is to avoid copious output from evaluating certain forms."
   (let ((map (make-sparse-keymap)))
     (define-key map "\C-c\C-b" 'ajrepl-send-buffer)
     (define-key map "\C-x\C-e" 'ajrepl-send-expression-at-point)
+    (define-key map "\C-\M-x" 'ajrepl-send-top-level-expression)
     (define-key map "\C-c\C-u" 'ajrepl-send-expression-upscoped)
     (define-key map "\C-c\C-r" 'ajrepl-send-region)
     (define-key map "\C-c\C-i" 'ajrepl-insert-last-output)
@@ -339,6 +350,7 @@ This is to avoid copious output from evaluating certain forms."
       '("Ajrepl"
         ["Send buffer" ajrepl-send-buffer t]
         ["Send expression at point" ajrepl-send-expression-at-point t]
+        ["Send top-level expression" ajrepl-send-top-level-expression t]
         ["Send expression upscoped" ajrepl-send-expression-upscoped t]
         ["Send region" ajrepl-send-region t]
         "--"


### PR DESCRIPTION
This PR is an attempt to address #2.

The intention is for this to work for both users of `janet-mode` as well as `janet-ts-mode`.

I don't know if `bounds-of-thing-at-point` uses tree-sitter under the covers if appropriate bits are available.  Perhaps it doesn't matter in most cases...